### PR TITLE
Update to sniff and minor fix to readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Installation
 
 * Install [PHP_CodeSniffer](http://pear.php.net/PHP_CodeSniffer) with `pear install PHP_CodeSniffer`.
 * Checkout this repository as `PHPHttpCompatibility` into the `PHP/CodeSniffer/Standards` directory.
-* Use the coding standard with `phpcs --standard=PHPCompatibility`
+* Use the coding standard with `phpcs --standard=PHPHttpCompatibility`

--- a/Sniffs/Http/DeprecatedFunctionsSniff.php
+++ b/Sniffs/Http/DeprecatedFunctionsSniff.php
@@ -27,7 +27,7 @@ class PHPHttpCompatibility_Sniffs_Http_DeprecatedFunctionsSniff extends Generic_
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                      'http_cache_last_modified'       => null,
                                      'http_chunked_decode'            => null,
                                      'http_deflate'                   => null,


### PR DESCRIPTION
I had to change $forbiddenfunctions to public because I was getting the following fatal error:

```
PHP Fatal error:  Access level to PHPHttpCompatibility_Sniffs_Http_DeprecatedFunctionsSniff::$forbiddenFunctions must be public (as in class Generic_Sniffs_PHP_ForbiddenFunctionsSniff) in /var/www/git/PHPHttpCompatibility/Sniffs/Http/DeprecatedFunctionsSniff.php on line 20
PHP Stack trace:
PHP   1. {main}() /home/ubuntu/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:0
PHP   2. PHP_CodeSniffer_CLI->runphpcs() /home/ubuntu/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs:25
PHP   3. PHP_CodeSniffer_CLI->process() /home/ubuntu/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:95
PHP   4. PHP_CodeSniffer->initStandard() /home/ubuntu/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/CLI.php:830
PHP   5. PHP_CodeSniffer->registerSniffs() /home/ubuntu/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:560
PHP   6. include_once() /home/ubuntu/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer.php:1318
```
